### PR TITLE
Fix panel shade position

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "northem-light-atom-ui",
   "theme": "ui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A north-bluish light theme based on the same named color palette designed by Arctic Ice Studio. This is a light and more color-intensive variation.",
   "author": {
     "name": "Arctic Ice Studio",

--- a/styles/components/panels.less
+++ b/styles/components/panels.less
@@ -51,13 +51,6 @@ atom-panel {
   .text(normal);
   position: relative;
 }
-
-atom-panel.modal:after {
-  position: absolute;
-  left: -@component-padding;
-  right: -@component-padding;
-  bottom: -@component-padding;
-}
 /* +------------------------------------------------------------------------[1]-+ */
 
 /* +----------------------------------------------------------------------------+


### PR DESCRIPTION
Panels like the [fuzzy finder](https://atom.io/packages/fuzzy-finder) often cover the rest of the UI in a "shade" to help highlight the panel. In this theme, the shade was implemented as an ::after element with position absolute and negative insets to extend it beyond the screen.

However, its parent was position relative. An element with position absolute inside an element with position relative is relative to its parent. So the insets were sticking out only a little beyond the panel itself.

This change removes the whole `atom-panel.modal:after` selector because the default atom behavior seems to be what the theme was going for in the first place.

Fixes #1
