### PR TITLE
Fix tab bar placeholder too tall

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -131,6 +131,14 @@ copyright  Copyright (C) 2016                                       +
     transform: scale(1);
     opacity: 1;
   }
+
+  .placeholder {
+    height: @tab-height / 2;
+
+    &:after {
+      top: @tab-height / 2;
+    }
+  }
 }
 
 .platform-darwin {


### PR DESCRIPTION
When rearranging tabs, the placeholder was set to be about 40px tall. This would cause the overall tab bar height to increase. That felt pretty weird when you're trying to move a tab and the tab bar is resizing on you.