### PR TITLE
Fix missing LESSCSS variable prefix character

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -75,7 +75,7 @@ copyright  Copyright (C) 2017                                       +
 /*+--- Panel ---+*/
 @tool-panel-background-color: @base-background-color; //TODO:0 test
 @tool-panel-border-color: @base-border-color;
-@inset-panel-background-color: northem-light5;
+@inset-panel-background-color: @northem-light5;
 @inset-panel-border-color: @base-border-color;
 @panel-heading-background-color: @northem-light5;
 @panel-heading-border-color: @base-border-color;


### PR DESCRIPTION
> Closes #20 
Resolves steelbrain/linter-ui-default#370

The `northem-light5` LESSCSS variable was missing the LESSCSS variable `@` prefix causing an exception during the loading of the [steelbrain/linter-ui-default](https://github.com/steelbrain/linter-ui-default) package which makes use of the UI theme core variable.